### PR TITLE
ci: pack only package projects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,14 +90,17 @@ jobs:
         run: dotnet test "$DOTNET_TARGET" --no-build --configuration "$CONFIGURATION" --verbosity normal
 
       - name: Pack NuGet packages
-        run: >
-          dotnet pack "$DOTNET_TARGET"
-          --no-build
-          --configuration "$CONFIGURATION"
-          --output "$NUGET_OUTPUT"
-          /p:Version=${{ steps.version.outputs.version }}
-          /p:PackageVersion=${{ steps.version.outputs.version }}
-          /p:MinVerVersionOverride=${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          while IFS= read -r -d '' project; do
+            dotnet pack "$project" \
+              --no-build \
+              --configuration "$CONFIGURATION" \
+              --output "$NUGET_OUTPUT" \
+              /p:Version=${{ steps.version.outputs.version }} \
+              /p:PackageVersion=${{ steps.version.outputs.version }} \
+              /p:MinVerVersionOverride=${{ steps.version.outputs.version }}
+          done < <(find src -name '*.csproj' -print0 | sort -z)
 
       - name: Create or update release tag
         shell: bash

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary

Fixes the release packaging step so NuGet pack only runs for package projects under `src`.

## Why

The release workflow was running `dotnet pack .`, which allowed sample projects to be evaluated during packaging. The Rabbit sample references SQLite for the outbox demo, so the pack step surfaced the SQLite vulnerability warning even though samples should never be packaged.

## Changes

- Pack each `src/**/*.csproj` project explicitly in the release workflow.
- Add `samples/Directory.Build.props` with `IsPackable=false` so sample projects stay non-packable even if someone runs `dotnet pack` from the repository root.

## Validation

- `dotnet build . --configuration Release /p:Version=2.0.0 /p:PackageVersion=2.0.0 /p:MinVerVersionOverride=2.0.0`
- Local pack loop over `src/**/*.csproj` generated only the package projects and symbols, with no sample packages.