### PR TITLE
feat: configure ambient transaction publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ------
 
+## [v2.1.0] - 2026-08-05
+
+### Added
+
+- Configurable direct publish behavior when an ambient transaction is active through `ConfigurePublishing`.
+- `AmbientTransactionPublishBehavior.SuppressTransaction` for publishing directly to brokers outside the ambient transaction.
+- `AmbientTransactionPublishBehavior.Throw` for failing fast when direct broker publishing is attempted inside an ambient transaction.
+
+------
+
 ## [v2.0.0] - 2026-07-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -195,6 +195,33 @@ await producer.PublishRawAsync(
     topic: "hello-world");
 ```
 
+### Publish Inside an Ambient Transaction
+
+When `PublishAsync` runs inside a `TransactionScope` and the transactional outbox is not enabled, Pigeon suppresses the ambient transaction for the direct broker publish by default. This keeps brokers that do not participate in the current transaction from trying to enlist in it:
+
+```csharp
+builder.Services.AddPigeon(builder.Configuration, config =>
+{
+    config.ConfigurePublishing(publishing =>
+    {
+        publishing.AmbientTransactionBehavior =
+            AmbientTransactionPublishBehavior.SuppressTransaction;
+    });
+});
+```
+
+Suppressing the transaction means the broker publish is not atomic with the surrounding business transaction. If the message must be consistent with database changes, enable the transactional outbox instead.
+
+Use `Throw` when you want Pigeon to fail fast if direct broker publishing happens inside an ambient transaction:
+
+```csharp
+config.ConfigurePublishing(publishing =>
+{
+    publishing.AmbientTransactionBehavior =
+        AmbientTransactionPublishBehavior.Throw;
+});
+```
+
 ### Route a Message to Multiple Consumers
 
 Adapters that support broker-side routing can publish one message and deliver it to multiple configured consumers. In RabbitMQ, for example, one publish can target an exchange and routing key while each consumer owns its queue and binding:

--- a/src/Pigeon.Messaging/DependencyInjection/GlobalSettingsBuilder.cs
+++ b/src/Pigeon.Messaging/DependencyInjection/GlobalSettingsBuilder.cs
@@ -8,6 +8,7 @@
     using Pigeon.Messaging.Consuming.Management;
     using Pigeon.Messaging.Contracts;
     using Pigeon.Messaging.Outbox;
+    using Pigeon.Messaging.Producing;
     using Pigeon.Messaging.Topology;
     using System.Reflection;
     using System.Text.Json;
@@ -110,6 +111,20 @@
                 throw new ArgumentNullException(nameof(configure));
 
             configure(GlobalSettings.ConsumerExecution);
+            return this;
+        }
+
+        /// <summary>
+        /// Configures global publishing behavior.
+        /// </summary>
+        /// <param name="configure">The publishing configuration action.</param>
+        /// <returns>The same <see cref="GlobalSettingsBuilder"/> instance for chaining.</returns>
+        public GlobalSettingsBuilder ConfigurePublishing(Action<PublishingSettings> configure)
+        {
+            if (configure == null)
+                throw new ArgumentNullException(nameof(configure));
+
+            configure(GlobalSettings.Publishing);
             return this;
         }
 

--- a/src/Pigeon.Messaging/GlobalSettings.cs
+++ b/src/Pigeon.Messaging/GlobalSettings.cs
@@ -3,6 +3,7 @@
     using Pigeon.Messaging.Topology;
     using Pigeon.Messaging.Consuming.Management;
     using Pigeon.Messaging.Outbox;
+    using Pigeon.Messaging.Producing;
     using System.Reflection;
 
     /// <summary>
@@ -43,6 +44,11 @@
         /// Gets or sets how consumed messages are buffered and processed.
         /// </summary>
         public ConsumerExecutionSettings ConsumerExecution { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets publishing behavior.
+        /// </summary>
+        public PublishingSettings Publishing { get; set; } = new();
 
         /// <summary>
         /// Gets or sets transactional outbox settings.

--- a/src/Pigeon.Messaging/Producing/AmbientTransactionPublishBehavior.cs
+++ b/src/Pigeon.Messaging/Producing/AmbientTransactionPublishBehavior.cs
@@ -1,0 +1,18 @@
+namespace Pigeon.Messaging.Producing
+{
+    /// <summary>
+    /// Defines how direct broker publishing behaves when an ambient transaction is active.
+    /// </summary>
+    public enum AmbientTransactionPublishBehavior
+    {
+        /// <summary>
+        /// Suppresses the ambient transaction while publishing directly to the broker.
+        /// </summary>
+        SuppressTransaction = 0,
+
+        /// <summary>
+        /// Throws when direct broker publishing is attempted inside an ambient transaction.
+        /// </summary>
+        Throw = 1
+    }
+}

--- a/src/Pigeon.Messaging/Producing/Producer.cs
+++ b/src/Pigeon.Messaging/Producing/Producer.cs
@@ -6,6 +6,7 @@ namespace Pigeon.Messaging.Producing
     using Pigeon.Messaging.Outbox;
     using Pigeon.Messaging.Producing.Management;
     using System;
+    using System.Transactions;
 
     /// <summary>
     /// Provides a base implementation for a message producer with support for publish interceptors,
@@ -190,7 +191,8 @@ namespace Pigeon.Messaging.Producing
                 return;
             }
 
-            await _producingManager.PushAsync(payload, route, cancellationToken);
+            await PublishDirectAsync(
+                () => _producingManager.PushAsync(payload, route, cancellationToken));
         }
 
         private async ValueTask PublishRawCore<T>(T message, PublishingRoute route, CancellationToken cancellationToken = default) where T : class
@@ -201,7 +203,8 @@ namespace Pigeon.Messaging.Producing
                 return;
             }
 
-            await _producingManager.PushRawAsync(message, route, cancellationToken);
+            await PublishDirectAsync(
+                () => _producingManager.PushRawAsync(message, route, cancellationToken));
         }
 
         private async Task EnqueueOutboxAsync(object payload, PublishingRoute route, bool isRaw, CancellationToken cancellationToken)
@@ -219,5 +222,31 @@ namespace Pigeon.Messaging.Producing
 
         private bool IsOutboxEnabled()
             => _settings.Outbox?.Enabled == true;
+
+        private async ValueTask PublishDirectAsync(Func<ValueTask> publish)
+        {
+            if (publish == null)
+                throw new ArgumentNullException(nameof(publish));
+
+            if (Transaction.Current == null)
+            {
+                await publish();
+                return;
+            }
+
+            var behavior = _settings.Publishing?.AmbientTransactionBehavior
+                ?? AmbientTransactionPublishBehavior.SuppressTransaction;
+
+            if (behavior == AmbientTransactionPublishBehavior.Throw)
+                throw new InvalidOperationException("Direct broker publishing cannot run inside an ambient transaction with the current Pigeon publishing settings.");
+
+            using var scope = new TransactionScope(
+                TransactionScopeOption.Suppress,
+                TransactionScopeAsyncFlowOption.Enabled);
+
+            await publish();
+
+            scope.Complete();
+        }
     }
 }

--- a/src/Pigeon.Messaging/Producing/PublishingSettings.cs
+++ b/src/Pigeon.Messaging/Producing/PublishingSettings.cs
@@ -1,0 +1,15 @@
+namespace Pigeon.Messaging.Producing
+{
+    /// <summary>
+    /// Defines global publishing behavior for Pigeon producers.
+    /// </summary>
+    public class PublishingSettings
+    {
+        /// <summary>
+        /// Gets or sets how direct broker publishing behaves when an ambient transaction is active.
+        /// Defaults to suppressing the ambient transaction for direct broker publishes.
+        /// </summary>
+        public AmbientTransactionPublishBehavior AmbientTransactionBehavior { get; set; }
+            = AmbientTransactionPublishBehavior.SuppressTransaction;
+    }
+}

--- a/tests/Pigeon.Messaging.Tests/DependencyInjection/GlobalSettingsBuilderTests.cs
+++ b/tests/Pigeon.Messaging.Tests/DependencyInjection/GlobalSettingsBuilderTests.cs
@@ -7,6 +7,7 @@
     using Pigeon.Messaging.Consuming.Configuration;
     using Pigeon.Messaging.Consuming.Dispatching;
     using Pigeon.Messaging.Contracts;
+    using Pigeon.Messaging.Producing;
     using System;
     using System.Linq;
     using System.Reflection;
@@ -106,6 +107,21 @@
             builder.AddFeature(fb => invoked = true);
 
             Assert.True(invoked);
+        }
+
+        [Fact]
+        public void ConfigurePublishing_Should_Update_Publishing_Settings()
+        {
+            var builder = CreateBuilder();
+
+            builder.ConfigurePublishing(settings =>
+            {
+                settings.AmbientTransactionBehavior = AmbientTransactionPublishBehavior.Throw;
+            });
+
+            Assert.Equal(
+                AmbientTransactionPublishBehavior.Throw,
+                builder.GlobalSettings.Publishing.AmbientTransactionBehavior);
         }
 
         [Fact]

--- a/tests/Pigeon.Messaging.Tests/Producing/ProducerTests.cs
+++ b/tests/Pigeon.Messaging.Tests/Producing/ProducerTests.cs
@@ -7,6 +7,7 @@ namespace Pigeon.Messaging.Tests.Producing
     using Pigeon.Messaging.Producing;
     using Pigeon.Messaging.Producing.Management;
     using System.Text.Json;
+    using System.Transactions;
 
     public class ProducerTests
     {
@@ -193,6 +194,123 @@ namespace Pigeon.Messaging.Tests.Producing
         }
 
         [Fact]
+        public async Task PublishAsync_Should_Suppress_Ambient_Transaction_For_Direct_Publish_By_Default()
+        {
+            Transaction observedTransaction = null;
+            var manager = Substitute.For<IProducingManager>();
+            manager
+                .PushAsync(Arg.Any<WrappedPayload<string>>(), Arg.Any<PublishingRoute>(), Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    observedTransaction = Transaction.Current;
+                    return ValueTask.CompletedTask;
+                });
+
+            var producer = new Producer(
+                Enumerable.Empty<IPublishInterceptor>(),
+                manager,
+                Options.Create(new GlobalSettings { Domain = "test-domain" }));
+
+            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+            await producer.PublishAsync("msg", "topic");
+
+            Assert.Null(observedTransaction);
+            Assert.NotNull(Transaction.Current);
+
+            scope.Complete();
+        }
+
+        [Fact]
+        public async Task PublishRawAsync_Should_Suppress_Ambient_Transaction_For_Direct_Publish_By_Default()
+        {
+            Transaction observedTransaction = null;
+            var manager = Substitute.For<IProducingManager>();
+            manager
+                .PushRawAsync("msg", Arg.Any<PublishingRoute>(), Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    observedTransaction = Transaction.Current;
+                    return ValueTask.CompletedTask;
+                });
+
+            var producer = new Producer(
+                Enumerable.Empty<IPublishInterceptor>(),
+                manager,
+                Options.Create(new GlobalSettings { Domain = "test-domain" }));
+
+            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+            await producer.PublishRawAsync("msg", "topic");
+
+            Assert.Null(observedTransaction);
+            Assert.NotNull(Transaction.Current);
+
+            scope.Complete();
+        }
+
+        [Fact]
+        public async Task PublishAsync_Should_Throw_In_Ambient_Transaction_When_Configured()
+        {
+            var manager = Substitute.For<IProducingManager>();
+            var producer = new Producer(
+                Enumerable.Empty<IPublishInterceptor>(),
+                manager,
+                Options.Create(new GlobalSettings
+                {
+                    Domain = "test-domain",
+                    Publishing =
+                    {
+                        AmbientTransactionBehavior = AmbientTransactionPublishBehavior.Throw
+                    }
+                }));
+
+            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await producer.PublishAsync("msg", "topic"));
+            await manager.DidNotReceive().PushAsync(
+                Arg.Any<WrappedPayload<string>>(),
+                Arg.Any<PublishingRoute>(),
+                Arg.Any<CancellationToken>());
+
+            scope.Complete();
+        }
+
+        [Fact]
+        public async Task PublishAsync_Should_Not_Suppress_Ambient_Transaction_When_Outbox_Enabled()
+        {
+            var manager = Substitute.For<IProducingManager>();
+            var storage = new TestOutboxStorage();
+            var serializer = new TestSerializer();
+            var producer = new Producer(
+                Enumerable.Empty<IPublishInterceptor>(),
+                manager,
+                Options.Create(new GlobalSettings
+                {
+                    Domain = "test-domain",
+                    Publishing =
+                    {
+                        AmbientTransactionBehavior = AmbientTransactionPublishBehavior.Throw
+                    },
+                    Outbox = new OutboxSettings { Enabled = true }
+                }),
+                storage,
+                new OutboxMessageFactory(serializer));
+
+            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+            await producer.PublishAsync(new TestMessage { Text = "hello" }, "topic");
+
+            Assert.NotNull(storage.TransactionOnAdd);
+            await manager.DidNotReceive().PushAsync(
+                Arg.Any<WrappedPayload<TestMessage>>(),
+                Arg.Any<PublishingRoute>(),
+                Arg.Any<CancellationToken>());
+
+            scope.Complete();
+        }
+
+        [Fact]
         public async Task PublishAsync_Should_Throw_If_Message_Null()
         {
             var producer = GetProducer();
@@ -254,8 +372,11 @@ namespace Pigeon.Messaging.Tests.Producing
 
             public int SaveChangesCount { get; private set; }
 
+            public Transaction TransactionOnAdd { get; private set; }
+
             public Task AddAsync(OutboxMessage message, CancellationToken cancellationToken = default)
             {
+                TransactionOnAdd = Transaction.Current;
                 Messages.Add(message);
                 return Task.CompletedTask;
             }


### PR DESCRIPTION
## Summary

Adds configurable behavior for direct broker publishing when an ambient `TransactionScope` is active.

## Why

Some brokers, especially Azure Service Bus, should not be forced into the caller's ambient transaction for best-effort messages. Pigeon now lets apps decide whether direct publishes should suppress the ambient transaction or fail fast.

## Changes

- Add `PublishingSettings` and `AmbientTransactionPublishBehavior`.
- Add `ConfigurePublishing(...)` to global Pigeon configuration.
- Suppress ambient transactions by default for direct publishes when outbox is not enabled.
- Keep outbox behavior unchanged so outbox writes still participate in the ambient transaction.
- Document the behavior and prepare `v2.1.0` changelog notes.
- Add unit tests for wrapped publish, raw publish, throw mode, and outbox behavior inside ambient transactions.

## Validation

- `dotnet test . --configuration Release` passed for `net8.0`, `net9.0`, and `net10.0`.

Known non-blocking warnings remained from existing SQLite advisory output and Rabbit XML docs warnings.